### PR TITLE
Update Japanese text for clarity and accuracy

### DIFF
--- a/index.ja.html
+++ b/index.ja.html
@@ -38,7 +38,7 @@
     <h2>連絡先</h2>
     <p>私に連絡する場合は、以下のアドレスにメールを送るのが一番良い方法です。<!--
       -->（但し、私のプロジェクトに関する問い合わせは、メールではなく、<!--
-      -->そのプロジェクトのIssue Trackerにお願いします）</p>
+      -->そのプロジェクトのイシュートラッカーにお願いします）</p>
     <p><a href="mailto:hong&#64;minhee.org" rel="me"
       class="handle">hong&#64;minhee.org</a></p>
     <p>Matrixも使っています。アカウントは以下の通りです。</p>
@@ -58,7 +58,7 @@
     <ul>
       <li><a href="https://fedify.dev/">Fedify</a>はTypeScriptで作った<a
         href="https://www.w3.org/TR/activitypub/">ActivityPub</a>の実装であり、<!--
-        -->Fediverse向けのサーバーフレームワークです。</li>
+        -->フェディバース向けのサーバーフレームワークです。</li>
       <li><a href="https://logtape.org/">LogTape</a>は、Deno、Node.js、Bun、<!--
         -->エッジ環境、ブラウザで動作するシンプルなロギングライブラリです。</li>
       <li><a href="https://docs.hollo.social/">Hollo</a>は<a
@@ -122,7 +122,7 @@
             -->JSONデータを暗号学的に扱う為のDenoパッケージです。<a
             href="https://tools.ietf.org/html/rfc8785"><abbr
             title="JSON Canonicalization Scheme">JCS</abbr></a>、<!--
-            -->JSONダイジェスト、JSON Merkle treeを実装しています。</li>
+            -->JSONダイジェスト、JSONマークルツリーを実装しています。</li>
           <li><a href="https://github.com/dahlia/sqlalchemy-imageattach"
             >SQLAlchemy-ImageAttach</a>はSQLAlchemyの拡張機能で、<!--
             -->エンティティオブジェクトに画像を添付することができます。</li>
@@ -159,7 +159,7 @@
       <h2>脚注</h2>
       <p id="non-public"><span>&dagger;</span>
         当該サービスは、閲覧するだけでもログインを要求するでしょう。<!--
-        -->（残念に思います。）</p>
+        -->（残念に思います）</p>
     </div>
   </body>
 </html>

--- a/index.ja.html
+++ b/index.ja.html
@@ -14,7 +14,7 @@
       >洪<rp>(</rp><rt>ホン</rt><rp>)</rp>&nbsp;<rt>・</rt>民憙<rp>(</rp><rt
       >ミンヒ</rt><rp>)</rp></ruby>のホームページです。私は<a href="#projects"
       >自由・オープンソースソフトウェア</a>を作り、主にHaskell、Python、<!--
-      -->TypeScript 等の言語でコーディングしています。<a
+      -->TypeScript 等の言語でコードを書いています。<a
       href="https://www.gnu.org/philosophy/free-sw.html">自由</a>・<a
       href="https://opensource.org/osd">オープンソース</a>ソフトウェアと<a
       href="https://www.theverge.com/24063290/fediverse-explained-activitypub-social-media-open-protocol"
@@ -38,7 +38,7 @@
     <h2>連絡先</h2>
     <p>私に連絡する場合は、以下のアドレスにメールを送るのが一番良い方法です。<!--
       -->（但し、私のプロジェクトに関する問い合わせは、メールではなく、<!--
-      -->そのプロジェクトの課題トラッカーにお願いします）</p>
+      -->そのプロジェクトのIssue Trackerにお願いします）</p>
     <p><a href="mailto:hong&#64;minhee.org" rel="me"
       class="handle">hong&#64;minhee.org</a></p>
     <p>Matrixも使っています。アカウントは以下の通りです。</p>
@@ -58,9 +58,9 @@
     <ul>
       <li><a href="https://fedify.dev/">Fedify</a>はTypeScriptで作った<a
         href="https://www.w3.org/TR/activitypub/">ActivityPub</a>の実装であり、<!--
-        -->フェディバースサーバーフレームワークです。</li>
+        -->Fediverse向けのサーバーフレームワークです。</li>
       <li><a href="https://logtape.org/">LogTape</a>は、Deno、Node.js、Bun、<!--
-        -->エッジ関数、ブラウザで動作するシンプルなロギングライブラリ。</li>
+        -->エッジ環境、ブラウザで動作するシンプルなロギングライブラリです。</li>
       <li><a href="https://docs.hollo.social/">Hollo</a>は<a
         href="https://www.w3.org/TR/activitypub/">ActivityPub</a>に対応した<!--
         -->一人様向けの軽量マイクロブログソフトウェアです。</li>
@@ -69,7 +69,7 @@
       <li><a href="https://optique.dev/">Optique</a>はTypeScriptを対象とした<!--
         -->型安全なCLIパーサコンビネータです。</li>
       <li><a href="https://upyo.org/">Upyo</a>はDeno、Node.js、Bun、<!--
-        -->エッジ関数で動作するモダンなメールライブラリです。</li>
+        -->エッジ環境で動作するモダンなメールライブラリです。</li>
       <li><a href="https://github.com/dahlia/seonbi">Seonbi</a>は、<!--
         -->韓国語の様々な句読点校正と漢字ハングル混じり文をハングル専用文に<!--
         -->変換してくれるHTML前処理機です。</li>
@@ -78,12 +78,12 @@
           <li><a href="https://libplanet.io/">Libplanet</a>は、脱中央集権的な<!--
             -->マルチプレイヤーオンラインゲームを作成する為の.NETライブラリで、<!--
             -->全てのゲームプレイが特権的な中央サーバーではなく、<!--
-            -->同等のノード間のピアツーピアネットワークで行われるようにします。</li>
+            -->同等のノード間のP2Pネットワークで行われます。</li>
           <li><a href="https://bencodex.org/">Bencodex</a>はBitTorrentの<a
             href="http://www.bittorrent.org/beps/bep_0003.html#bencoding"
-            >Bencoding</a>を拡張したシリアル化フォーマットです。正規化の強制<!--
-            -->（つまり、値と符号の対称性）とJSONデータモデルに似たデータ型の<!--
-            -->サポートを持ちながら、元のBencodingと上位互換性があります。<!--
+            >Bencoding</a>を拡張したシリアライズフォーマットです。正規化の強制<!--
+            -->（つまり、値と符号の対称性）とJSONデータモデルに似たデータ型を<!--
+            -->サポートし、元のBencodingの上位互換です。<!--
             -->（つまり、すべての有効なBencoding表現は有効なBencodex表現<!--
             -->でもあります）私が仕様を書き、<a
             href="https://github.com/planetarium/bencodex-python">Python</a>、<a
@@ -117,12 +117,12 @@
             >Wikidata</a>クライアントライブラリです。</li>
           <li><a href="https://github.com/dahlia/aitertools">aitertools</a>は、<!--
            -->TypeScriptで非同期イテレータを扱う為のテスト済みのユーティリティ<!--
-           -->関数のコレクションです。</li>
+           -->関数コレクションです。</li>
           <li><a href="https://github.com/dahlia/json-hash">json-hash</a>は<!--
             -->JSONデータを暗号学的に扱う為のDenoパッケージです。<a
             href="https://tools.ietf.org/html/rfc8785"><abbr
             title="JSON Canonicalization Scheme">JCS</abbr></a>、<!--
-            -->JSONダイジェスト、JSONマクルツリーを実装しています。</li>
+            -->JSONダイジェスト、JSON Merkle treeを実装しています。</li>
           <li><a href="https://github.com/dahlia/sqlalchemy-imageattach"
             >SQLAlchemy-ImageAttach</a>はSQLAlchemyの拡張機能で、<!--
             -->エンティティオブジェクトに画像を添付することができます。</li>
@@ -130,7 +130,7 @@
             -->与えられたパッチ（またはプルリクエスト）から人が一目で分かる<!--
             -->チェックリストを作成する小さなプログラムです。</li>
           <li><a href="https://github.com/dahlia/iterfzf">iterfzf</a>は<!--
-            -->コマンドラインファジーファインダーであるfzfのPython<!--
+            -->コマンドラインでのあいまい検索ツールであるfzfのPython<!--
             -->インターフェースです。</li>
           <li><a href="https://github.com/sphinx-contrib/autoprogram"
             >sphinxcontrib-autoprogram</a>はコマンドラインプログラムを自動的に
@@ -158,8 +158,8 @@
       <hr>
       <h2>脚注</h2>
       <p id="non-public"><span>&dagger;</span>
-        当該サービスは、閲覧するだけでもログインが必要になります。<!--
-        -->（申し訳ございません）</p>
+        当該サービスは、閲覧するだけでもログインを要求するでしょう。<!--
+        -->（残念に思います。）</p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Making better that the naturality in Japanese translation

Important points.
- Japanese prefer English as-is when it comes to english-native concept
- fixed poor searchability w/ `エッジ環境` instead of `エッジ関数` (if you prefer `functions`, please give me a comment :3)